### PR TITLE
Remove the now unnecessary RHINO_PAT

### DIFF
--- a/.github/workflows/rhino-test.yml
+++ b/.github/workflows/rhino-test.yml
@@ -6,7 +6,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       R_VERSION: '4.1.0'
-      GITHUB_PAT: ${{ secrets.RHINO_PAT }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
### Changes
Remove `RHINO_PAT` from the CI. It was a PAT for my own account - a workaround to install Rhino before the repository was made public.

### How to test
The CI should still pass.