### PR TITLE
Chore: Updates Rhino to 1.2.1

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1001,10 +1001,10 @@
     },
     "rhino": {
       "Package": "rhino",
-      "Version": "1.2.0",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b88eea59a51f492c8ef62129f237830c",
+      "Hash": "04df0885e4e4f8f62c1c138109ac51ae",
       "Requirements": [
         "box",
         "cli",


### PR DESCRIPTION
* `rhino-showcase` should now use Rhino 1.2.1
